### PR TITLE
fix: full i18n compliance for LuCI frontend

### DIFF
--- a/luci-app-vnt2/htdocs/luci-static/resources/view/vnt2/config.js
+++ b/luci-app-vnt2/htdocs/luci-static/resources/view/vnt2/config.js
@@ -19,7 +19,7 @@ var callSetEnabled        = rpcDeclare('set_enabled',         ['type','configs']
 var callGetEnabled        = rpcDeclare('get_enabled',         ['type']);
 var callInstanceAction  = rpcDeclare('instance_action',  ['name', 'action']);
 
-var TABS          = { vnt:'客户端', vnts:'服务端' };
+var TABS          = { vnt:_('Client'), vnts:_('Server') };
 var START_METHODS = { vnt:['vnt2_cli','vnt2_web'], vnts:['vnts2'] };
 
 var _tab             = (location.hash === '#vnts') ? 'vnts' : 'vnt';
@@ -78,10 +78,10 @@ function saveListState(self) {
     return Promise.all(promises).then(function(results) {
         var failed = results.filter(function(r) { return r && r.result !== 'ok'; });
         if (failed.length) {
-            self._ui.notify('部分保存失败', 'error');
+            self._ui.notify(_('Partial save failed'), 'error');
             return;
         }
-        self._ui.notify('配置已保存', 'success');
+        self._ui.notify(_('配置已保存'), 'success');
         return new Promise(function(resolve) {
             window.setTimeout(function() {
                 refreshStatus(self).then(function() {
@@ -90,7 +90,7 @@ function saveListState(self) {
             }, 3000);
         });
     }).catch(function(err) {
-        self._ui.notify('保存出错：' + String(err), 'error');
+        self._ui.notify(_('Save error: ') + String(err), 'error');
     });
 }
 
@@ -120,7 +120,7 @@ function switchTab(self, tab) {
         }
     }
     if (editing && _dirty) {
-        self._ui.confirm('放弃修改', '有未保存的修改切换标签将丢失，确定吗？')
+        self._ui.confirm(_('Discard changes'), _('Unsaved changes will be lost when switching tabs, are you sure?'))
             .then(function(ok) { if (ok) doSwitch(); });
     } else {
         doSwitch();
@@ -168,9 +168,9 @@ function buildTable(self) {
     var configs = self._configs[_tab] || [];
     if (!configs.length)
         return E('p', { 'class':'vnt2-empty' },
-            '暂无' + TABS[_tab] + '配置，点击"新建配置"开始添加。');
+            _('No ') + TABS[_tab] + _(' config yet, click "New Config" to add.'));
     var thStyle = 'padding:8px 12px;text-align:center;';
-    var heads   = ['启用', '配置名称', '启动方式', '当前状态', '操作'];
+    var heads   = [_('Enabled'), _('Config Name'), _('Start Method'), _('Current Status'), _('Actions')];
     return E('div', { 'class':'vnt2-table-wrap', 'style':'width:100%;display:block;' },
         E('table', {
             'class': 'vnt2-table',
@@ -212,12 +212,12 @@ function buildRow(self, cfg) {
         'class': 'btn cbi-button-edit',
         'style': 'margin-right:6px;',
         'click': function() { openEditor(self, name, false); }
-    }, '编辑');
+    }, _('Edit'));
 
     var btnDel = E('button', {
         'class': 'btn cbi-button-negative',
         'click': function() { deleteConfig(self, name); }
-    }, '删除');
+    }, _('Delete'));
 
     var statusCell = E('td', { 'class':'vnt2-status-cell', 'style':tdStyle },
         self._ui.statusBadge(state.enabled ? (self._status && self._status[name]) : null));
@@ -312,7 +312,7 @@ if (isNew && tab === 'vnt') {
         'class':       'cbi-input-text',
         'style':       'width:auto;',
         'value':       name || '',
-        'placeholder': '字母、数字、下划线、连字符'
+        'placeholder': _('Letters, numbers, underscore, hyphen')
     });
     nameInput.addEventListener('input', function() {
     _dirty = true;
@@ -327,7 +327,7 @@ if (isNew && tab === 'vnt') {
 
     function backToList() {
         if (_dirty) {
-            self._ui.confirm('放弃修改', '有未保存的修改，确定放弃并返回吗？')
+            self._ui.confirm(_('Discard changes'), _('There are unsaved changes, are you sure to discard and return?'))
                 .then(function(ok) { if (ok) { _dirty = false; showList(); } });
         } else {
             showList();
@@ -340,38 +340,38 @@ if (isNew && tab === 'vnt') {
                 E('span', { 'class':'vnt2-breadcrumb-link', 'click':backToList },
                     TABS[tab] + '配置列表'),
                 E('span', { 'class':'vnt2-breadcrumb-sep' }, ' › '),
-                E('span', {}, (isNew ? '新建' : '编辑') + '配置')
+                E('span', {}, (isNew ? _('New ') : _('Edit ')) + _('Config'))
             ]),
             E('div', { 'style':'display:flex;align-items:center;margin-top:8px;' }, [
                 E('label', { 'style':'font-weight:bold;margin-right:6px;flex-shrink:0;' },
-                    '配置名称：'),
+                    _('Config Name: ')),
                 nameInput,
                 nameErr
             ])
         ]),
         E('div', { 'class':'vnt2-edit-body' }, formEl),
         E('div', {'class': 'vnt2-edit-footer', 'style': 'padding-top:60px;display:flex;gap:8px;' }, [
-            E('button', { 'class':'btn', 'click':backToList }, '← 返回列表'),
+            E('button', { 'class':'btn', 'click':backToList        }, '← ' + _('Back to list')),
             E('button', {
                 'class': 'btn cbi-button-save',
                 'click': function() {
                     var newName = nameInput.value.trim();
                     if (!newName || !/^[\w-]+$/.test(newName)) {
-                        nameErr.textContent   = '名称只能包含字母、数字、下划线、连字符';
+                        nameErr.textContent   = _('Name can only contain letters, numbers, underscore, hyphen');
                         nameErr.style.display = 'inline';
                         nameInput.focus();
                         return;
                     }
                     if (isNew && self._configs[tab] &&
                         self._configs[tab].some(function(c) { return c.name === newName; })) {
-                        nameErr.textContent   = '配置名称已存在';
+                        nameErr.textContent   = _('Config name already exists');
                         nameErr.style.display = 'inline';
                         nameInput.focus();
                         return;
                     }
                     saveConfig(self, name, newName, tab, formEl, fields, res.content);
                 }
-            }, '保存配置')
+            }, _('Save Config'))
         ])
     ]);
 }
@@ -379,7 +379,7 @@ if (isNew && tab === 'vnt') {
 function buildForm(fields, values) {
     var form = E('div', { 'class':'vnt2-dyn-form' });
     if (!fields.length) {
-        form.appendChild(E('p', { 'class':'vnt2-hint' }, '模板字段为空，请检查模板文件。'));
+        form.appendChild(E('p', { 'class':'vnt2-hint' }, _('Template fields are empty, please check the template file.')));
         return form;
     }
     fields.forEach(function(f) { form.appendChild(buildFormRow(f, values)); });
@@ -387,7 +387,7 @@ function buildForm(fields, values) {
 }
 
 function getPlaceholder(f) {
-    var m = (f.comment || '').match(/示例[：:]\s*(\S+)/);
+    var m = (f.comment || '').match(/Example[：:]\s*(\S+)/);
     return m ? m[1] : '';
 }
 
@@ -395,12 +395,12 @@ function buildFormRow(f, values) {
     var val = Object.prototype.hasOwnProperty.call(values, f.name)
         ? values[f.name]
         : (f.type === 'section' ? {} : f['default']);
-    var isRequired  = !!(f.comment && f.comment.indexOf('必填') !== -1);
+    var isRequired  = !!(f.comment && f.comment.indexOf(_('Required')) !== -1);
     var nameEl      = E('div', { 'class':'vnt2-field-name' });
     nameEl.appendChild(document.createTextNode(f.name));
     if (isRequired) nameEl.appendChild(E('span', { 'class':'vnt2-required-star' }, ' *'));
     var commentText = (f.comment || '')
-        .replace(/示例[：:]\s*\S+/g, '')
+        .replace(/Example[：:]\s*\S+/g, '')
         .replace(/\s+/g, ' ')
         .trim();
     return E('div', { 'class':'vnt2-field-row' }, [
@@ -428,14 +428,14 @@ function buildInput(f, val, isRequired) {
 
 function buildBool(f, val) {
     var checked = (val === 'true' || val === true);
-    var span    = E('span', { 'class':'vnt2-bool-label' }, checked ? '已启用' : '已禁用');
+    var span    = E('span', { 'class':'vnt2-bool-label' }, checked ? _('Enabled') : _('Disabled'));
     var cb      = E('input', {
         'type': 'checkbox', 'class': 'vnt2-checkbox',
         'data-field-name': f.name, 'data-field-type': 'bool'
     });
     if (checked) cb.setAttribute('checked', 'checked');
     cb.addEventListener('change', function() {
-        span.textContent = cb.checked ? '已启用' : '已禁用';
+        span.textContent = cb.checked ? _('Enabled') : _('Disabled');
     });
     return E('label', { 'class':'vnt2-bool-wrap' }, [cb, span]);
 }
@@ -460,7 +460,7 @@ function buildSelect(f, val) {
     });
     var options = [];
     if (!parsed.some(function(p) { return p.value === val; }) || val === '' || val == null)
-        options.push(E('option', { 'value':'' }, '— 请选择 —'));
+        options.push(E('option', { 'value':'' }, '— ' + _('Please select') + ' —'));
     parsed.forEach(function(p) {
         var a = { 'value':p.value };
         if (p.value === val) a['selected'] = 'selected';
@@ -505,7 +505,7 @@ function buildListField(f, items, cls) {
             'placeholder': getPlaceholder(f)
         });
         var btnAdd = E('button', {
-            'type': 'button', 'class': 'btn vnt2-array-btn-add', 'title': '添加一行',
+            'type': 'button', 'class': 'btn vnt2-array-btn-add', 'title': _('Add row'),
             'click': function(ev) {
                 ev.preventDefault();
                 var nr = addRow('');
@@ -517,7 +517,7 @@ function buildListField(f, items, cls) {
             }
         }, '+');
         var btnDel = E('button', {
-            'type': 'button', 'class': 'btn vnt2-array-btn-del', 'title': '删除此行',
+            'type': 'button', 'class': 'btn vnt2-array-btn-del', 'title': _('Delete row'),
             'click': function(ev) {
                 ev.preventDefault();
                 if (container.querySelectorAll('.vnt2-' + cls + '-row').length <= 1) {
@@ -606,7 +606,7 @@ function validate(fields, formEl) {
     });
     var errors = [];
     fields.forEach(function(f) {
-        if (!f.comment || f.comment.indexOf('必填') === -1) return;
+        if (!f.comment || f.comment.indexOf(_('Required')) === -1) return;
         if (f.type === 'array') {
             var c = formEl.querySelector(
                 '[data-field-name="' + f.name + '"][data-field-type="array"]'
@@ -637,7 +637,7 @@ function saveConfig(self, oldName, newName, tab, formEl, fields, templateContent
     loadListState(tab).then(function() {
         var errors = validate(fields, formEl);
         if (errors.length) {
-            self._ui.notify('以下必填项未填写：' + errors.join('、'), 'error');
+            self._ui.notify(_('The following required fields are not filled: ') + errors.join(', '), 'error');
             var first = formEl.querySelector('.vnt2-input-error');
             if (first) first.scrollIntoView({ behavior:'smooth', block:'center' });
             return;
@@ -648,7 +648,7 @@ function saveConfig(self, oldName, newName, tab, formEl, fields, templateContent
 
         callSaveConfig(newName, tab, content, oldName || '').then(function(r) {
             if (!r || r.result !== 'ok') {
-                self._ui.notify('保存失败：' + ((r && r.msg) || ''), 'error');
+                self._ui.notify(_('Save failed: ') + ((r && r.msg) || ''), 'error');
                 return;
             }
 
@@ -669,16 +669,16 @@ function saveConfig(self, oldName, newName, tab, formEl, fields, templateContent
 
             var state = _listState[tab][newName] || ensureState(tab, newName);
             if (state.enabled) {
-                self._ui.notify('实例已启用，正在重启...', 'success');
+                self._ui.notify(_('Instance enabled, restarting...'), 'success');
                 callInstanceAction(newName, 'restart').then(function(res) {
                     var ok = res && res.result === 'ok';
                     self._ui.notify(
-                        ok ? '实例 "' + newName + '" 重启成功'
-                           : '重启失败：' + ((res && res.msg) || '未知错误'),
+                        ok ? _('Instance "') + newName + _('" restart successful')
+                           : _('Restart failed: ') + ((res && res.msg) || _('Unknown error')),
                         ok ? 'success' : 'error'
                     );
                 }).catch(function(err) {
-                    self._ui.notify('重启出错：' + String(err), 'error');
+                    self._ui.notify(_('Restart error: ') + String(err), 'error');
                 });
             }
 
@@ -692,7 +692,7 @@ function saveConfig(self, oldName, newName, tab, formEl, fields, templateContent
                     saveListState(self);
                 });
         }).catch(function(err) {
-            self._ui.notify('保存出错：' + String(err), 'error');
+            self._ui.notify(_('Save error: ') + String(err), 'error');
         });
     });
 }
@@ -701,14 +701,14 @@ function deleteConfig(self, name) {
     var tab     = _tab;
     var running = !!(self._status && self._status[name]);
     var msg = running
-        ? '实例 "' + name + '" 正在运行，删除后将自动停止，确定吗？'
-        : '确定要删除配置 "' + name + '" 吗？';
+        ? _('Instance "') + name + _('" is running, will be stopped after deletion, continue?')
+        : _('Are you sure you want to delete config "') + name + '"?';
 
-    self._ui.confirm('确认删除', msg).then(function(ok) {
+    self._ui.confirm(_('Confirm Delete'), msg).then(function(ok) {
         if (!ok) return;
         callDeleteConfig(name, tab).then(function(r) {
             if (r && r.result === 'ok') {
-                self._ui.notify('配置 "' + name + '" 已删除', 'success');
+                self._ui.notify(_('Config "') + name + _('" deleted'), 'success');
                 delete _listState[tab][name];
                 return callListConfigs(tab).then(function(res) {
                     self._configs[tab] = (res && Array.isArray(res.configs))
@@ -716,7 +716,7 @@ function deleteConfig(self, name) {
                     rebuildTable(self);
                 });
             }
-            self._ui.notify('删除失败：' + ((r && r.msg) || ''), 'error');
+            self._ui.notify(_('Delete failed: ') + ((r && r.msg) || ''), 'error');
         });
     });
 }
@@ -759,7 +759,7 @@ return view.extend({
         startStatusTimer(self);
 
         var view = E('div', { 'class':'cbi-map' }, [
-            E('h2', {}, 'VNT2 配置管理'),
+            E('h2', {}, _('VNT2 Config Management')),
             E('div', { 'class':'cbi-section' }, [
                 E('div', {
                     'style': 'display:flex;border-bottom:2px solid #ddd;margin-bottom:16px;'
@@ -774,7 +774,7 @@ return view.extend({
                             'color:' + (active ? '#3498db' : '#666')
                         ].join(';'),
                         'click': function() { switchTab(self, t); }
-                    }, TABS[t] + '配置');
+                    }, TABS[t] + _('Config'));
                 })),
                 E('div', { 'id':'vnt2-list-wrap' }, [
                     E('div', {
@@ -784,14 +784,14 @@ return view.extend({
                         E('button', {
                             'class': 'btn cbi-button-add',
                             'click': function() { openEditor(self, '', true); }
-                        }, '+ 新建配置'),
+                        }, '+ ' + _('New Config')),
                         E('button', {
                             'class': 'btn cbi-button-save',
                             'click': function() { saveListState(self); }
-                        }, '保存并应用')
+                        }, _('Save & Apply')),
                     ]),
                     E('div', { 'id':'vnt2-table-wrap' },
-                        E('p', { 'class':'vnt2-loading' }, '加载中...')
+                        E('p', { 'class':'vnt2-loading' }, _('Loading...'))
                     )
                 ]),
                 E('div', { 'id':'vnt2-edit-wrap', 'style':'display:none;' })

--- a/luci-app-vnt2/htdocs/luci-static/resources/view/vnt2/log.js
+++ b/luci-app-vnt2/htdocs/luci-static/resources/view/vnt2/log.js
@@ -82,7 +82,7 @@ return view.extend({
         self._currentInstance = instances.length ? instances[0].name : null;
 
         var node = E('div', { 'class':'cbi-map' }, [
-            E('h2', {}, 'VNT2 日志'),
+            E('h2', {}, _('VNT2 Logs')),
             E('div', { 'class':'cbi-section' }, [
                 self._renderToolbar(),
                 E('pre', {
@@ -95,7 +95,7 @@ return view.extend({
                         'white-space:pre-wrap', 'word-break:break-all',
                         'margin-top:12px'
                     ].join(';')
-                }, self._currentInstance ? '加载中...' : '暂无实例')
+                }, self._currentInstance ? _('Loading...') : _('No instances'))
             ])
         ]);
 
@@ -114,8 +114,8 @@ return view.extend({
     },
 
     _instLabel: function(inst) {
-        var type   = inst.type === 'vnt' ? '客户端' : '服务端';
-        var status = inst.running ? '运行中' : '已停止';
+        var type   = inst.type === 'vnt' ? _('Client') : _('Server');
+        var status = inst.running ? _('Running') : _('Stopped');
         return inst.name + ' (' + type + ' · ' + status + ')';
     },
 
@@ -136,7 +136,7 @@ return view.extend({
                 if (inst.name === self._currentInstance) a['selected'] = 'selected';
                 return E('option', a, self._instLabel(inst));
               })
-            : [E('option', { 'value':'' }, '暂无实例')]
+            : [E('option', { 'value':'' }, _('No instances'))]
         );
 
         var linesSelect = E('select', {
@@ -147,7 +147,7 @@ return view.extend({
         }, LINE_OPTIONS.map(function(n) {
             var a = { 'value': String(n) };
             if (n === 200) a['selected'] = 'selected';
-            return E('option', a, n === 0 ? '全部' : '最近 ' + n + ' 行');
+            return E('option', a, n === 0 ? _('All') : _('Last ') + n + ' ' + _('lines'));
         }));
 
         var autoCheck = E('input', {
@@ -157,10 +157,10 @@ return view.extend({
         });
 
         var btns = [
-            { label:'刷新',     cls:'btn cbi-button-action',  fn: function() { self._loadLog(); }  },
-            { label:'清理日志', cls:'btn cbi-button-negative', fn: function() { self._clearLog(); } },
-            { label:'滚到顶部', cls:'btn',                     fn: function() { scrollLog(false); } },
-            { label:'滚到底部', cls:'btn',                     fn: function() { scrollLog(true);  } },
+            { label:_('Refresh'),     cls:'btn cbi-button-action',  fn: function() { self._loadLog(); }  },
+            { label:_('Clear Logs'), cls:'btn cbi-button-negative', fn: function() { self._clearLog(); } },
+            { label:_('Scroll to Top'), cls:'btn',                  fn: function() { scrollLog(false); } },
+            { label:_('Scroll to Bottom'), cls:'btn',               fn: function() { scrollLog(true);  } },
         ];
 
         return E('div', {
@@ -170,11 +170,11 @@ return view.extend({
                 'margin-bottom:12px'
             ].join(';')
         }, [
-            E('label', {}, '实例：'),
+            E('label', {}, _('Instance: ')),
             instanceSelect,
             linesSelect,
             E('label', { 'style':'cursor:pointer;user-select:none;' },
-                [autoCheck, '自动刷新(5s)']),
+                [autoCheck, _('Auto refresh (5s)')]),
         ].concat(btns.map(function(b) {
             return E('button', { 'class':b.cls, 'click':b.fn }, b.label);
         })));
@@ -205,10 +205,10 @@ return view.extend({
         if (!instances.length) {
             var opt         = document.createElement('option');
             opt.value       = '';
-            opt.textContent = '暂无实例';
+            opt.textContent = _('No instances');
             sel.appendChild(opt);
             var el = getLogEl();
-            if (el) el.textContent = '暂无实例';
+            if (el) el.textContent = _('No instances');
             return;
         }
 
@@ -254,7 +254,7 @@ return view.extend({
         if (!hasContent)
             el.appendChild(E('span', {
                 'style': 'color:#888;font-style:italic;'
-            }, '（暂无日志）'));
+            }, _('(No logs)')));
 
         el.scrollTop = el.scrollHeight;
     },
@@ -266,7 +266,7 @@ return view.extend({
         var lines   = linesEl ? parseInt(linesEl.value) : 200;
         var linesArg = lines === 0 ? null : lines;
         var el = getLogEl();
-        if (el) el.textContent = '加载中...';
+        if (el) el.textContent = _('Loading...');
 
         callGetLog(self._currentInstance, linesArg).then(function(r) {
             var content = (r && r.content) || '';
@@ -276,14 +276,14 @@ return view.extend({
                     el2.innerHTML = '';
                     el2.appendChild(E('span', {
                         'style': 'color:#888;font-style:italic;'
-                    }, '（暂无日志，实例可能尚未启动或未产生输出）'));
+                    }, _('(No logs, instance may not be started yet or has no output)')));
                 }
                 return;
             }
             self._formatLog(content);
         }).catch(function() {
             var el2 = getLogEl();
-            if (el2) el2.textContent = '加载日志失败';
+            if (el2) el2.textContent = _('Failed to load logs');
         });
     },
 

--- a/luci-app-vnt2/htdocs/luci-static/resources/view/vnt2/overview.js
+++ b/luci-app-vnt2/htdocs/luci-static/resources/view/vnt2/overview.js
@@ -14,10 +14,10 @@ var callGetCtrlInfo    = rpcDeclare('get_ctrl_info',    ['name', 'cmd']);
 var callGetCpuTicks    = rpcDeclare('get_cpu_ticks',    ['name']);
 
 var CTRL_TABS = [
-    { id:'info',    label:'基本信息' },
-    { id:'ips',     label:'IP 列表'  },
-    { id:'clients', label:'客户端'   },
-    { id:'route',   label:'路由'     }
+    { id:'info',    label:_('Basic Info') },
+    { id:'ips',     label:_('IP List')  },
+    { id:'clients', label:_('Clients')   },
+    { id:'route',   label:_('Routes')     }
 ];
 
 var BIN_KEYS = [
@@ -28,16 +28,16 @@ var BIN_KEYS = [
 ];
 
 var LINKS = [
-    ['http://rustvnt.com',                        '官网'  ],
+    ['http://rustvnt.com',                        _('Official')  ],
     ['https://github.com/vnt-dev/vnt',            'GitHub'],
     ['https://github.com/vnt-dev/VntApp',         'GUIApp'],
-    ['https://github.com/whzhni1/luci-app-vnt2', 'Luci'  ],
+    ['https://github.com/whzhni1/luci-app-vnt2', 'LuCI'  ],
 ];
 
 var ACTIONS = [
-    { id:'start',   label:'启动', needRunning:false },
-    { id:'restart', label:'重启', needRunning:true  },
-    { id:'stop',    label:'停止', needRunning:true  },
+    { id:'start',   label:_('Start'), needRunning:false },
+    { id:'restart', label:_('Restart'), needRunning:true  },
+    { id:'stop',    label:_('Stop'), needRunning:true  },
 ];
 
 var _lastTicks = {};
@@ -76,10 +76,10 @@ function formatUptime(seconds) {
     var m = Math.floor((seconds % 3600) / 60);
     var s = seconds % 60;
     var parts = [];
-    if (d > 0) parts.push(d + '天');
-    if (h > 0) parts.push(h + '时');
-    if (m > 0) parts.push(m + '分');
-    parts.push(s + '秒');
+    if (d > 0) parts.push(d + _(' days'));
+    if (h > 0) parts.push(h + _(' hrs'));
+    if (m > 0) parts.push(m + _(' mins'));
+    parts.push(s + _(' secs'));
     return parts.join('');
 }
 
@@ -124,50 +124,50 @@ return view.extend({
         self._activeCtrlTab    = 'info';
 
         var linkNodes = [E('span', {}, '💡 '), E('b', {}, 'VNT'),
-            E('span', {}, ' - 简便高效的异地组网工具 | ')];
+            E('span', {}, _(' - Simple and efficient remote networking tool | '))];
         LINKS.forEach(function(lk, i) {
             if (i > 0) linkNodes.push(E('span', {}, ' | '));
             linkNodes.push(E('a', { 'href':lk[0], 'target':'_blank' }, lk[1]));
         });
 
         var node = E('div', { 'class':'cbi-map' }, [
-            E('h2', {}, 'VNT2 概览'),
+            E('h2', {}, _('VNT2 Overview')),
             self._renderBinaryAlert(binaries),
             E('div', { 'class':'cbi-section' }, [
             E('div', { 'style':'display:flex;align-items:center;justify-content:space-between;margin-bottom:8px;' }, [
                 E('h3', { 'style':'margin:0;' }, [
-                    E('span', {}, '实例运行状态 '),
+                    E('span', {}, _('Instance Status ')),
                     E('span', {
                         'data-role': 'run-status',
                         'style':     'font-size:13px;font-weight:normal;color:#28a745;'
-                    }, instances.filter(function(i){ return i.running; }).length + ' 个运行中'),
+                    }, instances.filter(function(i){ return i.running; }).length + ' ' + _('running')),
                     E('span', {
                         'data-role': 'run-total',
                         'style':     'font-size:13px;font-weight:normal;color:#aaa;'
-                    }, ' / ' + instances.length + ' 个')
+                    }, ' / ' + instances.length + ' ' + _('total'))
                 ]),
                 E('div', { 'style':'display:flex;gap:6px;' }, [
                     E('button', {
                         'class': 'btn cbi-button-action',
                         'style': 'padding:3px 10px;font-size:12px;',
                         'click': function() { self._doBatchAction('start'); }
-                    }, '全部启动'),
+                    }, _('Start All')),
                     E('button', {
                         'class': 'btn cbi-button-action',
                         'style': 'padding:3px 10px;font-size:12px;',
                         'click': function() { self._doBatchAction('restart'); }
-                    }, '全部重启'),
+                    }, _('Restart All')),
                     E('button', {
                         'class': 'btn cbi-button',
                         'style': 'padding:3px 10px;font-size:12px;color:#dc3545;border-color:#dc3545;',
                         'click': function() { self._doBatchAction('stop'); }
-                    }, '全部停止'),
+                    }, _('Stop All')),
                 ])
             ]),
             self._renderInstanceTable(instances)
         ]),
             E('div', { 'class':'cbi-section' }, [
-                E('h3', {}, '节点信息'),
+                E('h3', {}, _('Node Info')),
                 self._renderCtrlPanel(instances)
             ]),
             E('div', {
@@ -209,15 +209,15 @@ return view.extend({
         });
         if (!missing.length) return E('span', {});
         return E('div', { 'class':'alert-message warning', 'style':'margin-bottom:16px;' }, [
-            E('strong', {}, '⚠ 程序文件缺失：'),
+            E('strong', {}, _('⚠ Binary files missing: ')),
             E('span',   {}, ' ' + missing.join(', ')),
             E('br'),
-            E('span',   {}, '请前往 '),
+            E('span',   {}, _('Please go to ')),
             E('a', {
                 'href':  L.url('admin/vpn/vnt2/settings'),
                 'style': 'text-decoration:underline;color:#0069d9;'
-            }, '设置与更新'),
-            E('span', {}, ' 页面下载安装。')
+            }, _('Settings & Update')),
+            E('span', {}, _(' page to download and install.'))
         ]);
     },
 
@@ -225,9 +225,9 @@ return view.extend({
         var self = this;
         if (!instances.length)
             return E('p', { 'style':'color:#888;' },
-                '暂无实例，请先在客户端或服务端配置页新建实例。');
+                _('No instances yet. Please create one in client or server config page first.'));
         var thStyle = 'padding:8px 12px;text-align:center;';
-        var heads   = ['实例名称','实例类型','运行时间','PID','CPU／RAM','快捷操作','Web UI'];
+        var heads   = [_('Instance Name'),_('Type'),_('Uptime'),'PID',_('CPU/RAM'),_('Quick Actions'),'Web UI'];
         return E('div', { 'class':'vnt2-table-wrap', 'style':'width:100%;display:block;' },
             E('table', {
                 'class': 'vnt2-table',
@@ -254,7 +254,7 @@ return view.extend({
             + runningColor(running) + ';';
         return E('tr', { 'id':'vnt2-row-' + inst.name }, [
             E('td', { 'class':'vnt2-col-name', 'style':tdStyle }, inst.name),
-            E('td', { 'style':tdStyle }, inst.type === 'vnt' ? '客户端' : '服务端'),
+            E('td', { 'style':tdStyle }, inst.type === 'vnt' ? _('Client') : _('Server')),
             E('td', { 'id':'vnt2-uptime-'  + inst.name, 'style':tdStyle },
                 running ? formatUptime(inst.uptime) : '-'),
             E('td', { 'id':'vnt2-pid-'     + inst.name, 'style':tdStyle }, inst.pid || '-'),
@@ -292,7 +292,7 @@ return view.extend({
                 'href':   window.location.protocol + '//' + window.location.hostname + ':' + port,
                 'target': '_blank',
                 'style':  'font-size:18px;text-decoration:none;',
-                'title':  '进入 Web 管理'
+                'title':  _('Enter Web Admin')
             }, '🌐 ');
         }
         return E('span', { 'style':'color:#ccc;' }, '-');
@@ -305,13 +305,13 @@ return view.extend({
                 ? result && (result.result === 'ok' || result.result === 'not_running')
                 : result && result.result === 'ok';
             self._ui.notify(
-                '实例 "' + name + '" ' + act.label +
-                (ok ? ' 成功' : ' 失败：' + ((result && result.msg) || '未知错误')),
+                _('Instance "') + name + '" ' + act.label +
+                (ok ? _(' success') : _(' failed: ') + ((result && result.msg) || _('Unknown error'))),
                 ok ? 'success' : 'error'
             );
             refreshList(self);
         }).catch(function(err) {
-            self._ui.notify('操作失败：' + String(err), 'error');
+            self._ui.notify(_('Operation failed: ') + String(err), 'error');
         });
     },
 
@@ -323,14 +323,14 @@ return view.extend({
         callInstanceAction(null, actId).then(function(r) {
             var results = (r && Array.isArray(r.results)) ? r.results : [];
             if (!results.length && r && r.result === 'ok') {
-                self._ui.notify('全部 ' + act.label + ' 指令已发送', 'success');
+                self._ui.notify(_('All ') + act.label + _(' commands sent'), 'success');
                 refreshList(self);
                 return;
             }
 
             if (!results.length) {
                 self._ui.notify(
-                    '没有' + (act.needRunning ? '运行中' : '已停止') + '的实例可供' + act.label,
+                    _('No ') + (act.needRunning ? _('running') : _('stopped')) + _(' instances available for ') + act.label,
                     'error'
                 );
                 return;
@@ -339,15 +339,15 @@ return view.extend({
             var failed = results.filter(function(item) { return item.result !== 'ok'; });
             self._ui.notify(
                 failed.length
-                    ? act.label + ' 部分失败：' + failed.map(function(item) {
-                        return '"' + item.name + '"' + (item.msg ? '：' + item.msg : '');
-                    }).join('、')
-                    : '全部 ' + act.label + ' 成功（共 ' + results.length + ' 个）',
+                    ? act.label + _(' partially failed: ') + failed.map(function(item) {
+                        return '"' + item.name + '"' + (item.msg ? ': ' + item.msg : '');
+                    }).join(', ')
+                    : _('All ') + act.label + _(' success (total ') + results.length + ')',
                 failed.length ? 'error' : 'success'
             );
             refreshList(self);
         }).catch(function(err) {
-            self._ui.notify('批量' + act.label + '失败：' + String(err), 'error');
+            self._ui.notify(_('Batch ') + act.label + _(' failed: ') + String(err), 'error');
         });
     },
 
@@ -372,7 +372,7 @@ return view.extend({
                 wrap.appendChild(E('p', {
                     'id':    'vnt2-no-inst-tip',
                     'style': 'color:#888;'
-                }, '暂无运行中的客户端实例。'));
+                }, _('No running client instances.')));
                 self._selectedInstance = null;
             }
             return;
@@ -456,12 +456,12 @@ return view.extend({
                 'id':    'vnt2-ctrl-tab-' + t.id,
                 'style': 'display:' + (t.id === self._activeCtrlTab ? 'block' : 'none')
                        + ';padding:12px 0;'
-            }, E('p', { 'style':'color:#888;font-style:italic;' }, '加载中...'));
+            }, E('p', { 'style':'color:#888;font-style:italic;' }, _('Loading...')));
         }));
 
         return E('div', {}, [
             E('div', { 'style':'display:flex;align-items:center;gap:8px;' }, [
-                E('label', {}, '选择实例：'),
+                E('label', {}, _('Select instance: ')),
                 instSelect,
                 E('button', {
                     'class': 'btn cbi-button-action',
@@ -469,7 +469,7 @@ return view.extend({
                         if (self._selectedInstance)
                             self._loadCtrlTab(self._selectedInstance, self._activeCtrlTab);
                     }
-                }, '刷新')
+                }, _('Refresh'))
             ]),
             tabHeader,
             tabBody
@@ -500,8 +500,8 @@ return view.extend({
         callGetCtrlInfo(name, cmd).then(function(r) {
             el.innerHTML = '';
             var output = ((r && r.output) || '').replace(/\x1b\[[0-9;]*m/g, '');
-            if (!output || output === '非客户端实例' || output === '控制端口已禁用') {
-                el.appendChild(E('p', { 'style':'color:#888;' }, output || '暂无数据'));
+            if (!output || output === _('Non-client instance') || output === _('Control port disabled')) {
+                el.appendChild(E('p', { 'style':'color:#888;' }, output || _('No data')));
                 return;
             }
             el.appendChild(E('pre', {
@@ -513,7 +513,7 @@ return view.extend({
                 ].join(';')
             }, output));
         }).catch(function() {
-            el.innerHTML = '<p style="color:#e00;">加载失败</p>';
+            el.innerHTML = '<p style="color:#e00;">' + _('Loading failed') + '</p>';
         });
     },
 
@@ -558,8 +558,8 @@ return view.extend({
         var runCount = instances.filter(function(i) { return i.running; }).length;
         var statusEl = document.querySelector('[data-role="run-status"]');
         var totalEl  = document.querySelector('[data-role="run-total"]');
-        if (statusEl) statusEl.textContent = runCount + ' 个运行中';
-        if (totalEl)  totalEl.textContent  = ' / ' + instances.length + ' 个';
+        if (statusEl) statusEl.textContent = runCount + ' ' + _('running');
+        if (totalEl)  totalEl.textContent  = ' / ' + instances.length + ' ' + _('total');
         var wrap = document.getElementById('vnt2-ctrl-panel-wrap');
         if (wrap) {
             self._syncCtrlPanelDom(

--- a/luci-app-vnt2/htdocs/luci-static/resources/view/vnt2/settings.js
+++ b/luci-app-vnt2/htdocs/luci-static/resources/view/vnt2/settings.js
@@ -37,12 +37,12 @@ var COMPONENTS = [
 ];
 
 var FW_OPTIONS = [
-    { key: 'fw_vnt_to_lan', label: 'VNT → LAN', desc: '允许虚拟网络访问本地局域网' },
-    { key: 'fw_lan_to_vnt', label: 'LAN → VNT', desc: '允许本地局域网访问虚拟网络' },
-    { key: 'fw_vnt_to_wan', label: 'VNT → WAN', desc: '允许虚拟网络访问外网'       },
-    { key: 'fw_wan_to_vnt', label: 'WAN → VNT', desc: '允许外网访问虚拟网络'       },
-    { key: 'fw_vnt_web',    label: 'VNT Web 外网访问',  desc: '需配置 web_addr'    },
-    { key: 'fw_vnts_web',   label: 'VNTS Web 外网访问', desc: '需配置 web_bind'    },
+    { key: 'fw_vnt_to_lan', label: 'VNT → LAN', desc: _('Allow virtual network to access local LAN') },
+    { key: 'fw_lan_to_vnt', label: 'LAN → VNT', desc: _('Allow local LAN to access virtual network') },
+    { key: 'fw_vnt_to_wan', label: 'VNT → WAN', desc: _('Allow virtual network to access WAN')       },
+    { key: 'fw_wan_to_vnt', label: 'WAN → VNT', desc: _('Allow WAN to access virtual network')       },
+    { key: 'fw_vnt_web',    label: 'VNT Web WAN Access',  desc: _('Requires web_addr configuration')    },
+    { key: 'fw_vnts_web',   label: 'VNTS Web WAN Access', desc: _('Requires web_bind configuration')    },
 ];
 
 return view.extend({
@@ -62,10 +62,10 @@ return view.extend({
         self._sysinfo  = data[2] || {};
         self._binaries = data[3] || {};
         return E('div', { 'class': 'cbi-map' }, [
-            E('h2', {}, 'VNT2 设置与更新'),
+            E('h2', {}, _('VNT2 Settings & Update')),
             self._buildTabContainer([
-                { id: 'tab-settings', label: '设置', content: self._buildSettingsTab() },
-                { id: 'tab-update',   label: '更新', content: self._buildUpdateTab()   }
+                { id: 'tab-settings', label: _('Settings'), content: self._buildSettingsTab() },
+                { id: 'tab-update',   label: _('Update'),   content: self._buildUpdateTab()   }
             ])
         ]);
     },
@@ -168,7 +168,7 @@ return view.extend({
             return vui.buildFormRow(opt.label,
                 E('label', { 'style': 'cursor:pointer;user-select:none;' }, [
                     buildCheck('s-' + opt.key, opt.key),
-                    E('span', { 'style': 'margin-left:6px;' }, '启用')
+                    E('span', { 'style': 'margin-left:6px;' }, _('Enable'))
                 ]), opt.desc || '');
         }
 
@@ -183,23 +183,23 @@ return view.extend({
 
         return E('div', {}, [
             E('div', { 'class': 'cbi-section' }, [
-                E('h3', {}, '基本设置'),
-                vui.buildFormRow('二进制程序路径',
+                E('h3', {}, _('Basic Settings')),
+                vui.buildFormRow(_('Binary Path'),
                     buildText('s-bin-path', 'bin_path'),
-                    '程序文件所在目录，默认 /usr/bin'),
-                vui.buildFormRow('配置文件路径',
+                    _('Program file directory, default /usr/bin')),
+                vui.buildFormRow(_('Config Path'),
                     buildText('s-config-path', 'config_path'),
-                    '配置文件存储目录，默认 /etc/vnt2_config'),
-                vui.buildFormRow('设备架构',
+                    _('Configuration file storage directory, default /etc/vnt2_config')),
+                vui.buildFormRow(_('Device Architecture'),
                     buildText('s-arch', 'arch', 'width:200px;'),
-                    '当前检测：' + (self._sysinfo.arch || '未知')),
-                vui.buildFormRow('下载镜像源', mirrorSel, '多镜像源确保成功下载'),
-                vui.buildFormRow('自动更新',
+                    _('Current detection: ') + (self._sysinfo.arch || _('Unknown'))),
+                vui.buildFormRow(_('Download Mirror'), mirrorSel, _('Multiple mirrors ensure successful download')),
+                vui.buildFormRow(_('Auto Update'),
                     E('label', { 'style': 'cursor:pointer;user-select:none;' }, [
                         buildCheck('s-auto-update', 'auto_update'),
-                        E('span', { 'style': 'margin-left:6px;' }, '启用自动更新')
-                    ]), '定期自动检查并更新程序'),
-                vui.buildFormRow('更新间隔（天）',
+                        E('span', { 'style': 'margin-left:6px;' }, _('Enable auto update'))
+                    ]), _('Automatically check and update programs periodically')),
+                vui.buildFormRow(_('Update Interval (days)'),
                     E('input', { 'type': 'number', 'class': 'cbi-input-text',
                         'id': 's-interval',
                         'value': g('update_interval') || '7',
@@ -207,15 +207,15 @@ return view.extend({
                         'change': function() {
                             uci.set('vnt2', 'global', 'update_interval', this.value || '7');
                         }
-                    }), '自动检查更新的间隔天数'),
-                vui.buildFormRow('UPX 压缩',
+                    }), _('Interval days for automatic update check')),
+                vui.buildFormRow(_('UPX Compression'),
                     E('label', { 'style': 'cursor:pointer;user-select:none;' }, [
                         buildCheck('s-upx', 'upx_compressed'),
-                        E('span', { 'style': 'margin-left:6px;' }, '安装后使用 UPX 压缩')
-                    ]), '可显著减小程序文件体积')
+                        E('span', { 'style': 'margin-left:6px;' }, _('Compress with UPX after installation'))
+                    ]), _('Can significantly reduce program file size'))
             ]),
             E('div', { 'class': 'cbi-section' }, [
-                E('h3', {}, '防火墙转发'),
+                E('h3', {}, _('Firewall Forwarding')),
                 E('div', {}, FW_OPTIONS.map(buildCheckRow))
             ])
         ]);
@@ -227,7 +227,7 @@ return view.extend({
         var tdStyle = 'padding:8px 12px;text-align:center;vertical-align:middle;';
 
         return E('div', { 'class': 'cbi-section' }, [
-            E('h3', {}, '当前版本信息'),
+            E('h3', {}, _('Current Version Info')),
             E('div', { 'style': 'width:100%;display:block;margin-bottom:20px;' },
                 E('table', {
                     'style': [
@@ -237,35 +237,35 @@ return view.extend({
                     ].join(';')
                 }, [
                     E('thead', {}, E('tr', {},
-                        ['组件', '版本', '状态'].map(function(h) {
+                        [_('Component'), _('Version'), _('Status')].map(function(h) {
                             return E('th', { 'style': thStyle }, h);
                         })
                     )),
                     E('tbody', {}, [
                         E('tr', {}, [
                             E('td', { 'style': tdStyle }, 'luci-app-vnt2'),
-                            E('td', { 'style': tdStyle }, sys.luci_version || '未知'),
-                            E('td', { 'style': tdStyle + 'color:#28a745;font-weight:bold;' }, '✓ 已安装')
+                            E('td', { 'style': tdStyle }, sys.luci_version || _('Unknown')),
+                            E('td', { 'style': tdStyle + 'color:#28a745;font-weight:bold;' }, '✓ ' + _('Installed'))
                         ])
                     ].concat(COMPONENTS.map(function(comp) {
                         var installed = !!bins[comp.binKey];
                         return E('tr', {}, [
                             E('td', { 'style': tdStyle }, comp.name),
                             E('td', { 'style': tdStyle },
-                                installed ? (sys[comp.versionKey] || '未知') : '未安装'),
+                                installed ? (sys[comp.versionKey] || _('Unknown')) : _('Not installed')),
                             E('td', { 'style': tdStyle + 'color:' +
                                 (installed ? '#28a745' : '#dc3545') + ';font-weight:bold;' },
-                                installed ? '✓ 已安装' : '✗ 未安装')
+                                installed ? '✓ ' + _('Installed') : '✗ ' + _('Not installed'))
                         ]);
                     })))
                 ])
             ),
-            E('h3', {}, '检查更新'),
-            self._buildUpdateBlock('luci-app-vnt2', 'LuCI 插件（luci-app-vnt2）'),
+            E('h3', {}, _('Check Update')),
+            self._buildUpdateBlock('luci-app-vnt2', _('LuCI Plugin (luci-app-vnt2)')),
             E('div', { 'style': 'margin:12px 0;border-top:1px solid #eee;' }),
-            self._buildUpdateBlock('vnt',  'VNT 客户端（vnt2_cli / vnt2_web / vnt2_ctrl）'),
+            self._buildUpdateBlock('vnt',  _('VNT Client (vnt2_cli / vnt2_web / vnt2_ctrl)')),
             E('div', { 'style': 'margin:12px 0;border-top:1px solid #eee;' }),
-            self._buildUpdateBlock('vnts', 'VNTS 服务端（vnts2）')
+            self._buildUpdateBlock('vnts', _('VNTS Server (vnts2))'))
         ]);
     },
 
@@ -283,13 +283,13 @@ return view.extend({
                     'class': 'btn cbi-button-action',
                     'id':    bid + '-check-btn',
                     'click': function() { self._checkUpstream(project, bid); }
-                }, '检查上游版本'),
+                }, _('Check upstream version')),
                 E('span', { 'id': bid + '-status', 'style': 'font-size:13px;color:#888;' },
-                    '点击检查获取版本信息')
+                    _('Click to check for version info'))
             ]),
             E('div', { 'id': bid + '-mirror-row',
                 'style': 'display:none;margin-top:8px;align-items:center;gap:8px;' }, [
-                E('span', { 'style': 'font-size:13px;color:#666;' }, '切换镜像源重试：'),
+                E('span', { 'style': 'font-size:13px;color:#666;' }, _('Switch mirror and retry:')),
                 E('select', {
                     'class': 'cbi-input-select',
                     'id':    bid + '-mirror',
@@ -302,22 +302,22 @@ return view.extend({
                 E('button', {
                     'class': 'btn cbi-button-action',
                     'click': function() { self._checkUpstream(project, bid); }
-                }, '重试')
+                }, _('Retry'))
             ]),
             E('div', { 'id': bid + '-selects',
                 'style': 'display:none;margin-top:10px;' }, [
                 E('div', { 'style': 'display:flex;flex-wrap:wrap;align-items:center;gap:8px;' }, [
-                    E('label', {}, '版本：'),
+                    E('label', {}, _('Version: ')),
                     E('select', { 'class': 'cbi-input-select', 'id': bid + '-tag',
                         'style': 'width:auto;' }),
-                    E('label', {}, '文件：'),
+                    E('label', {}, _('File: ')),
                     E('select', { 'class': 'cbi-input-select', 'id': bid + '-file',
                         'style': 'width:auto;' }),
                     E('button', {
                         'class': 'btn cbi-button-apply',
                         'id':    bid + '-btn',
                         'click': function() { self._doUpdate(project, bid); }
-                    }, '立即更新')
+                    }, _('Update Now'))
                 ])
             ]),
             E('pre', { 'id': bid + '-log',
@@ -366,12 +366,12 @@ return view.extend({
         self._hide(bid + '-mirror-row');
         self._hide(bid + '-selects');
         self._hide(bid + '-log');
-        self._setStatus(bid, '检查中...', '#888');
+        self._setStatus(bid, _('Checking...'), '#888');
         callGetUpstreamVersion(project, mirror).then(function() {
             self._pollStatus(project, bid, 'check');
         }).catch(function(err) {
             if (checkBtn) checkBtn.disabled = false;
-            self._setStatus(bid, '✗ 启动失败: ' + String(err), '#dc3545');
+            self._setStatus(bid, '✗ ' + _('Start failed: ') + String(err), '#dc3545');
             self._show(bid + '-mirror-row', true);
         });
     },
@@ -385,7 +385,7 @@ return view.extend({
         var fname  = fileEl ? fileEl.value : '';
 
         if (!tag || !fname) {
-            self._setStatus(bid, '✗ 请先检查版本', '#dc3545');
+            self._setStatus(bid, '✗ ' + _('Please check version first'), '#dc3545');
             return;
         }
 
@@ -394,20 +394,20 @@ return view.extend({
 
         if (btn) btn.disabled = true;
         self._hide(bid + '-mirror-row');
-        self._showLog(bid, '准备下载...');
-        self._setStatus(bid, '下载中...', '#888');
+        self._showLog(bid, _('Preparing download...'));
+        self._setStatus(bid, _('Downloading...'), '#888');
 
         callDoUpdate(project, tag, fname, upx).then(function(r) {
             if (!r || r.result !== 'ok') {
                 if (btn) btn.disabled = false;
-                self._setStatus(bid, '✗ 启动下载失败', '#dc3545');
+                self._setStatus(bid, '✗ ' + _('Start download failed'), '#dc3545');
                 self._show(bid + '-mirror-row', true);
                 return;
             }
             self._pollStatus(project, bid, 'download');
         }).catch(function(err) {
             if (btn) btn.disabled = false;
-            self._setStatus(bid, '✗ 错误: ' + String(err), '#dc3545');
+            self._setStatus(bid, '✗ ' + _('Error: ') + String(err), '#dc3545');
             self._show(bid + '-mirror-row', true);
         });
     },
@@ -434,37 +434,37 @@ return view.extend({
                 if (done || !s) return;
                 var dot = '.'.repeat(dots % 4 + 1);
                 if (s.status === 'checking') {
-                    self._setStatus(bid, '检查中' + dot, '#888');
+                    self._setStatus(bid, _('Checking') + dot, '#888');
                     return;
                 }
                 if (s.status === 'downloading') {
                     if (s.log) self._showLog(bid, s.log);
-                    self._setStatus(bid, '下载中' + dot, '#888');
+                    self._setStatus(bid, _('Downloading') + dot, '#888');
                     return;
                 }
                 if (s.status === 'installing' || s.status === 'processing') {
                     if (s.log) self._showLog(bid, s.log);
-                    self._setStatus(bid, '安装中...', '#888');
+                    self._setStatus(bid, _('Installing...'), '#888');
                     return;
                 }
                 stopAll();
                 if (s.status === 'ready') {
                     if (checkBtn) checkBtn.disabled = false;
-                    self._setStatus(bid, '✓ 找到 ' + s.count + ' 个版本', '#28a745');
+                    self._setStatus(bid, '✓ ' + _('Found ') + s.count + ' ' + _('versions'), '#28a745');
                     self._populateReleases(s.releases, bid);
                     self._show(bid + '-selects');
                     return;
                 }
                 if (s.status === 'done') {
                     if (btn) btn.disabled = false;
-                    self._setStatus(bid, '✓ 安装完成：' + (s.installed || ''), '#28a745');
+                    self._setStatus(bid, '✓ ' + _('Installation complete: ') + (s.installed || ''), '#28a745');
                     if (s.log) self._showLog(bid, s.log);
                     return;
                 }
                 if (s.status === 'error') {
                     if (checkBtn) checkBtn.disabled = false;
                     if (btn)      btn.disabled      = false;
-                    self._setStatus(bid, '✗ ' + (s.msg || '失败'), '#dc3545');
+                    self._setStatus(bid, '✗ ' + (s.msg || _('Failed')), '#dc3545');
                     if (s.log) self._showLog(bid, s.log);
                     self._show(bid + '-mirror-row', true);
                     return;
@@ -478,7 +478,7 @@ return view.extend({
             stopAll();
             if (checkBtn) checkBtn.disabled = false;
             if (btn)      btn.disabled      = false;
-            self._setStatus(bid, '✗ 超时，请重试', '#dc3545');
+            self._setStatus(bid, '✗ ' + _('Timeout, please retry'), '#dc3545');
             self._show(bid + '-mirror-row', true);
         }, timeoutMs);
     },

--- a/luci-app-vnt2/htdocs/luci-static/resources/vnt2/common.js
+++ b/luci-app-vnt2/htdocs/luci-static/resources/vnt2/common.js
@@ -282,11 +282,11 @@ var VNT2UI = {
                     E('button', {
                         'class':'btn', 'style':'margin-right:8px;',
                         'click': function() { L.ui.hideModal(); resolve(false); }
-                    }, '取消'),
+                    }, _('Cancel')),
                     E('button', {
                         'class':'btn cbi-button-action important',
                         'click': function() { L.ui.hideModal(); resolve(true); }
-                    }, '确认')
+                    }, _('Confirm'))
                 ])
             ]);
         });
@@ -294,10 +294,10 @@ var VNT2UI = {
 
     statusBadge: function(running) {
         if (running === undefined || running === null)
-            return E('span', { 'style':'color:#999;font-size:13px;' }, '未启用');
+            return E('span', { 'style':'color:#999;font-size:13px;' }, _('Disabled'));
         return E('span', {
             'style': 'color:' + (running ? '#28a745' : '#dc3545') + ';font-weight:bold;font-size:13px;'
-        }, running ? '✓ 运行中' : '✗ 未运行');
+        }, running ? '✓ ' + _('Running') : '✗ ' + _('Not running'));
     },
 
     buildFormRow: function(label, inputEl, desc) {

--- a/luci-app-vnt2/po/zh_Hans/vnt2.po
+++ b/luci-app-vnt2/po/zh_Hans/vnt2.po
@@ -1,0 +1,567 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+
+msgid "Basic Info"
+msgstr "基本信息"
+
+msgid "IP List"
+msgstr "IP 列表"
+
+msgid "Clients"
+msgstr "客户端"
+
+msgid "Routes"
+msgstr "路由"
+
+msgid "Official"
+msgstr "官网"
+
+msgid "Start"
+msgstr "启动"
+
+msgid "Restart"
+msgstr "重启"
+
+msgid "Stop"
+msgstr "停止"
+
+msgid " days"
+msgstr "天"
+
+msgid " hrs"
+msgstr "时"
+
+msgid " mins"
+msgstr "分"
+
+msgid " secs"
+msgstr "秒"
+
+msgid " - Simple and efficient remote networking tool | "
+msgstr " - 简便高效的异地组网工具 | "
+
+msgid "VNT2 Overview"
+msgstr "VNT2 概览"
+
+msgid "Instance Status "
+msgstr "实例运行状态 "
+
+msgid "running"
+msgstr "个运行中"
+
+msgid "total"
+msgstr "个"
+
+msgid "Start All"
+msgstr "全部启动"
+
+msgid "Restart All"
+msgstr "全部重启"
+
+msgid "Stop All"
+msgstr "全部停止"
+
+msgid "Node Info"
+msgstr "节点信息"
+
+msgid "\u26a0 Binary files missing: "
+msgstr "\u26a0 程序文件缺失："
+
+msgid "Please go to "
+msgstr "请前往 "
+
+msgid "Settings & Update"
+msgstr "设置与更新"
+
+msgid " page to download and install."
+msgstr " 页面下载安装。"
+
+msgid "No instances yet. Please create one in client or server config page first."
+msgstr "暂无实例，请先在客户端或服务端配置页新建实例。"
+
+msgid "Instance Name"
+msgstr "实例名称"
+
+msgid "Type"
+msgstr "实例类型"
+
+msgid "Uptime"
+msgstr "运行时间"
+
+msgid "CPU/RAM"
+msgstr "CPU／RAM"
+
+msgid "Quick Actions"
+msgstr "快捷操作"
+
+msgid "Client"
+msgstr "客户端"
+
+msgid "Server"
+msgstr "服务端"
+
+msgid "Enter Web Admin"
+msgstr "进入 Web 管理"
+
+msgid 'Instance "'
+msgstr "实例 \""
+
+msgid " success"
+msgstr " 成功"
+
+msgid " failed: "
+msgstr " 失败："
+
+msgid "Unknown error"
+msgstr "未知错误"
+
+msgid "Operation failed: "
+msgstr "操作失败："
+
+msgid "All "
+msgstr "全部 "
+
+msgid " commands sent"
+msgstr " 指令已发送"
+
+msgid "No "
+msgstr "没有"
+
+msgid "stopped"
+msgstr "已停止"
+
+msgid " instances available for "
+msgstr "的实例可供"
+
+msgid " partially failed: "
+msgstr " 部分失败："
+
+msgid "Batch "
+msgstr "批量"
+
+msgid "No running client instances."
+msgstr "暂无运行中的客户端实例。"
+
+msgid "Select instance: "
+msgstr "选择实例："
+
+msgid "Refresh"
+msgstr "刷新"
+
+msgid "Loading..."
+msgstr "加载中..."
+
+msgid "Non-client instance"
+msgstr "非客户端实例"
+
+msgid "Control port disabled"
+msgstr "控制端口已禁用"
+
+msgid "No data"
+msgstr "暂无数据"
+
+msgid "Loading failed"
+msgstr "加载失败"
+
+msgid "Client"
+msgstr "客户端"
+
+msgid "Server"
+msgstr "服务端"
+
+msgid "Discard changes"
+msgstr "放弃修改"
+
+msgid "Unsaved changes will be lost when switching tabs, are you sure?"
+msgstr "有未保存的修改切换标签将丢失，确定吗？"
+
+msgid "There are unsaved changes, are you sure to discard and return?"
+msgstr "有未保存的修改，确定放弃并返回吗？"
+
+msgid "No "
+msgstr "暂无"
+
+msgid " config yet, click \"New Config\" to add."
+msgstr "配置，点击\"新建配置\"开始添加。"
+
+msgid "Enabled"
+msgstr "启用"
+
+msgid "Config Name"
+msgstr "配置名称"
+
+msgid "Start Method"
+msgstr "启动方式"
+
+msgid "Current Status"
+msgstr "当前状态"
+
+msgid "Actions"
+msgstr "操作"
+
+msgid "Edit"
+msgstr "编辑"
+
+msgid "Delete"
+msgstr "删除"
+
+msgid "New "
+msgstr "新建"
+
+msgid "Edit "
+msgstr "编辑"
+
+msgid "Config"
+msgstr "配置"
+
+msgid "Config Name: "
+msgstr "配置名称："
+
+msgid "Letters, numbers, underscore, hyphen"
+msgstr "字母、数字、下划线、连字符"
+
+msgid "Name can only contain letters, numbers, underscore, hyphen"
+msgstr "名称只能包含字母、数字、下划线、连字符"
+
+msgid "Config name already exists"
+msgstr "配置名称已存在"
+
+msgid "Back to list"
+msgstr "返回列表"
+
+msgid "Save Config"
+msgstr "保存配置"
+
+msgid "Template fields are empty, please check the template file."
+msgstr "模板字段为空，请检查模板文件。"
+
+msgid "Please select"
+msgstr "请选择"
+
+msgid "Disabled"
+msgstr "已禁用"
+
+msgid "Enabled"
+msgstr "已启用"
+
+msgid "Add row"
+msgstr "添加一行"
+
+msgid "Delete row"
+msgstr "删除此行"
+
+msgid "Required"
+msgstr "必填"
+
+msgid "The following required fields are not filled: "
+msgstr "以下必填项未填写："
+
+msgid "Save failed: "
+msgstr "保存失败："
+
+msgid "Instance enabled, restarting..."
+msgstr "实例已启用，正在重启..."
+
+msgid '\" restart successful'
+msgstr '\" 重启成功'
+
+msgid "Restart failed: "
+msgstr "重启失败："
+
+msgid "Restart error: "
+msgstr "重启出错："
+
+msgid "Save error: "
+msgstr "保存出错："
+
+msgid 'Instance "'
+msgstr "实例 \""
+
+msgid '\" is running, will be stopped after deletion, continue?'
+msgstr '\" 正在运行，删除后将自动停止，确定吗？'
+
+msgid 'Are you sure you want to delete config "'
+msgstr "确定要删除配置 \""
+
+msgid "Confirm Delete"
+msgstr "确认删除"
+
+msgid 'Config "'
+msgstr "配置 \""
+
+msgid '\" deleted'
+msgstr '\" 已删除'
+
+msgid "Delete failed: "
+msgstr "删除失败："
+
+msgid "VNT2 Config Management"
+msgstr "VNT2 配置管理"
+
+msgid "Config"
+msgstr "配置"
+
+msgid "New Config"
+msgstr "新建配置"
+
+msgid "Save & Apply"
+msgstr "保存并应用"
+
+msgid "Cancel"
+msgstr "取消"
+
+msgid "Confirm"
+msgstr "确认"
+
+msgid "Disabled"
+msgstr "未启用"
+
+msgid "Running"
+msgstr "运行中"
+
+msgid "Not running"
+msgstr "未运行"
+
+msgid "VNT2 Settings & Update"
+msgstr "VNT2 设置与更新"
+
+msgid "Settings"
+msgstr "设置"
+
+msgid "Update"
+msgstr "更新"
+
+msgid "Basic Settings"
+msgstr "基本设置"
+
+msgid "Binary Path"
+msgstr "二进制程序路径"
+
+msgid "Program file directory, default /usr/bin"
+msgstr "程序文件所在目录，默认 /usr/bin"
+
+msgid "Config Path"
+msgstr "配置文件路径"
+
+msgid "Configuration file storage directory, default /etc/vnt2_config"
+msgstr "配置文件存储目录，默认 /etc/vnt2_config"
+
+msgid "Device Architecture"
+msgstr "设备架构"
+
+msgid "Current detection: "
+msgstr "当前检测："
+
+msgid "Unknown"
+msgstr "未知"
+
+msgid "Download Mirror"
+msgstr "下载镜像源"
+
+msgid "Multiple mirrors ensure successful download"
+msgstr "多镜像源确保成功下载"
+
+msgid "Auto Update"
+msgstr "自动更新"
+
+msgid "Enable auto update"
+msgstr "启用自动更新"
+
+msgid "Automatically check and update programs periodically"
+msgstr "定期自动检查并更新程序"
+
+msgid "Update Interval (days)"
+msgstr "更新间隔（天）"
+
+msgid "Interval days for automatic update check"
+msgstr "自动检查更新的间隔天数"
+
+msgid "UPX Compression"
+msgstr "UPX 压缩"
+
+msgid "Compress with UPX after installation"
+msgstr "安装后使用 UPX 压缩"
+
+msgid "Can significantly reduce program file size"
+msgstr "可显著减小程序文件体积"
+
+msgid "Firewall Forwarding"
+msgstr "防火墙转发"
+
+msgid "Enable"
+msgstr "启用"
+
+msgid "Allow virtual network to access local LAN"
+msgstr "允许虚拟网络访问本地局域网"
+
+msgid "Allow local LAN to access virtual network"
+msgstr "允许本地局域网访问虚拟网络"
+
+msgid "Allow virtual network to access WAN"
+msgstr "允许虚拟网络访问外网"
+
+msgid "Allow WAN to access virtual network"
+msgstr "允许外网访问虚拟网络"
+
+msgid "VNT Web WAN Access"
+msgstr "VNT Web 外网访问"
+
+msgid "Requires web_addr configuration"
+msgstr "需配置 web_addr"
+
+msgid "VNTS Web WAN Access"
+msgstr "VNTS Web 外网访问"
+
+msgid "Requires web_bind configuration"
+msgstr "需配置 web_bind"
+
+msgid "Current Version Info"
+msgstr "当前版本信息"
+
+msgid "Component"
+msgstr "组件"
+
+msgid "Version"
+msgstr "版本"
+
+msgid "Status"
+msgstr "状态"
+
+msgid "Installed"
+msgstr "已安装"
+
+msgid "Not installed"
+msgstr "未安装"
+
+msgid "Check Update"
+msgstr "检查更新"
+
+msgid "LuCI Plugin (luci-app-vnt2)"
+msgstr "LuCI 插件（luci-app-vnt2）"
+
+msgid "VNT Client (vnt2_cli / vnt2_web / vnt2_ctrl)"
+msgstr "VNT 客户端（vnt2_cli / vnt2_web / vnt2_ctrl）"
+
+msgid "VNTS Server (vnts2))"
+msgstr "VNTS 服务端（vnts2）"
+
+msgid "Check upstream version"
+msgstr "检查上游版本"
+
+msgid "Click to check for version info"
+msgstr "点击检查获取版本信息"
+
+msgid "Switch mirror and retry:"
+msgstr "切换镜像源重试："
+
+msgid "Retry"
+msgstr "重试"
+
+msgid "Version: "
+msgstr "版本："
+
+msgid "File: "
+msgstr "文件："
+
+msgid "Update Now"
+msgstr "立即更新"
+
+msgid "Checking..."
+msgstr "检查中..."
+
+msgid "Start failed: "
+msgstr "启动失败: "
+
+msgid "Please check version first"
+msgstr "请先检查版本"
+
+msgid "Preparing download..."
+msgstr "准备下载..."
+
+msgid "Downloading..."
+msgstr "下载中..."
+
+msgid "Start download failed"
+msgstr "启动下载失败"
+
+msgid "Error: "
+msgstr "错误: "
+
+msgid "Checking"
+msgstr "检查中"
+
+msgid "Downloading"
+msgstr "下载中"
+
+msgid "Installing..."
+msgstr "安装中..."
+
+msgid "Found "
+msgstr "找到 "
+
+msgid "versions"
+msgstr "个版本"
+
+msgid "Installation complete: "
+msgstr "安装完成："
+
+msgid "Failed"
+msgstr "失败"
+
+msgid "Timeout, please retry"
+msgstr "超时，请重试"
+
+msgid "VNT2 Logs"
+msgstr "VNT2 日志"
+
+msgid "No instances"
+msgstr "暂无实例"
+
+msgid "Stopped"
+msgstr "已停止"
+
+msgid "All"
+msgstr "全部"
+
+msgid "Last "
+msgstr "最近 "
+
+msgid "lines"
+msgstr "行"
+
+msgid "Clear Logs"
+msgstr "清理日志"
+
+msgid "Scroll to Top"
+msgstr "滚到顶部"
+
+msgid "Scroll to Bottom"
+msgstr "滚到底部"
+
+msgid "Instance: "
+msgstr "实例："
+
+msgid "Auto refresh (5s)"
+msgstr "自动刷新(5s)"
+
+msgid "(No logs)"
+msgstr "（暂无日志）"
+
+msgid "(No logs, instance may not be started yet or has no output)"
+msgstr "（暂无日志，实例可能尚未启动或未产生输出）"
+
+msgid "Failed to load logs"
+msgstr "加载日志失败"
+
+msgid "Partial save failed"
+msgstr "部分保存失败"
+
+msgid "Configuration saved"
+msgstr "配置已保存"
+
+msgid "Save error: "
+msgstr "保存出错："
+
+msgid "Running"
+msgstr "运行中"

--- a/luci-app-vnt2/root/usr/share/luci/menu.d/luci-app-vnt2.json
+++ b/luci-app-vnt2/root/usr/share/luci/menu.d/luci-app-vnt2.json
@@ -8,7 +8,7 @@
     "icon": "wifi"
   },
   "admin/vpn/vnt2/overview": {
-    "title": "概览",
+    "title": "Overview",
     "order": 10,
     "action": {
       "type": "view",
@@ -16,7 +16,7 @@
     }
   },
   "admin/vpn/vnt2/config": {
-    "title": "配置管理",
+    "title": "Config Management",
     "order": 20,
     "action": {
       "type": "view",
@@ -24,7 +24,7 @@
     }
   },
   "admin/vpn/vnt2/log": {
-    "title": "日志",
+    "title": "Logs",
     "order": 30,
     "action": {
       "type": "view",
@@ -32,7 +32,7 @@
     }
   },
   "admin/vpn/vnt2/settings": {
-    "title": "设置与更新",
+    "title": "Settings & Update",
     "order": 40,
     "action": {
       "type": "view",


### PR DESCRIPTION
## Changes

- Replace all hardcoded Chinese strings in JS frontend files with English wrapped in `_()` translation function
- Files: `overview.js`, `config.js`, `settings.js`, `log.js`, `common.js`
- Translate `menu.d/luci-app-vnt2.json` page titles to English
- Add `po/zh_Hans/vnt2.po` with 150+ Chinese translations

## Why

All visible strings in LuCI applications should be wrapped with `_()` so they can be translated via po files. The original code had hardcoded Chinese strings directly in JS, which:
1. Breaks non-Chinese users (shows Chinese regardless of browser language)
2. Prevents the build system from generating `luci-i18n-vnt2-*` translation packages
3. Violates LuCI i18n conventions

## Coverage

Labels, buttons, status messages, notifications, table headers, validation errors, tooltips, log viewer UI, firewall option descriptions, update status messages.